### PR TITLE
Add Spinner/Loader Component

### DIFF
--- a/src/components/Spinner.stories.tsx
+++ b/src/components/Spinner.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Spinner } from './Spinner'
+
+const meta = {
+  title: 'Components/Spinner',
+  component: Spinner,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'white'],
+    },
+    label: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof Spinner>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {},
+}
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+  },
+}
+
+export const Medium: Story = {
+  args: {
+    size: 'md',
+  },
+}
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+  },
+}
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+  },
+}
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+  },
+}
+
+export const White: Story = {
+  args: {
+    variant: 'white',
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+}
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Spinner size="sm" />
+      <Spinner size="md" />
+      <Spinner size="lg" />
+    </div>
+  ),
+}
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Spinner variant="primary" />
+      <Spinner variant="secondary" />
+      <div className="bg-gray-800 p-4 rounded">
+        <Spinner variant="white" />
+      </div>
+    </div>
+  ),
+}
+
+export const InlineLoading: Story = {
+  render: () => (
+    <p className="flex items-center gap-2">
+      Fetching data...
+      <Spinner size="sm" />
+    </p>
+  ),
+}
+
+export const ButtonLoadingState: Story = {
+  render: () => (
+    <button
+      disabled
+      className="bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center gap-2"
+    >
+      <Spinner size="sm" variant="white" />
+      Creating...
+    </button>
+  ),
+}
+
+export const FullPageOverlay: Story = {
+  render: () => (
+    <div className="flex items-center justify-center w-96 h-64 bg-gray-50 rounded-lg">
+      <div className="flex flex-col items-center gap-4">
+        <Spinner size="lg" label="Loading chart..." />
+        <p className="text-gray-600">Loading chart...</p>
+      </div>
+    </div>
+  ),
+}
+
+export const CustomLabel: Story = {
+  args: {
+    label: 'Loading chart data...',
+    size: 'lg',
+  },
+}

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+export interface SpinnerProps {
+  size?: 'sm' | 'md' | 'lg'
+  variant?: 'primary' | 'secondary' | 'white'
+  className?: string
+  label?: string
+}
+
+export const Spinner: React.FC<SpinnerProps> = ({
+  size = 'md',
+  variant = 'primary',
+  className = '',
+  label = 'Loading...',
+}) => {
+  const sizes = {
+    sm: 'w-4 h-4 border-2',
+    md: 'w-8 h-8 border-2',
+    lg: 'w-12 h-12 border-3',
+  }
+
+  const variants = {
+    primary: 'border-blue-600 border-t-transparent',
+    secondary: 'border-gray-600 border-t-transparent',
+    white: 'border-white border-t-transparent',
+  }
+
+  return (
+    <div
+      className={`${sizes[size]} ${variants[variant]} rounded-full animate-spin ${className}`}
+      role="status"
+      aria-label={label}
+    >
+      <span className="sr-only">{label}</span>
+    </div>
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,6 @@ export type { CardProps, CardHeaderProps, CardTitleProps, CardContentProps } fro
 
 export { Input } from './components/Input'
 export type { InputProps } from './components/Input'
+
+export { Spinner } from './components/Spinner'
+export type { SpinnerProps } from './components/Spinner'


### PR DESCRIPTION
## Summary
- Implement Spinner/Loader component for loading states across applications
- Add 3 size variants: sm (16px), md (32px), lg (48px)
- Add 3 color variants: primary (blue), secondary (gray), white
- Full accessibility support with role="status", aria-label, and sr-only text
- Comprehensive Storybook stories with 13 examples including button loading, inline loading, and full-page overlay

## Test plan
- [x] Component implemented in src/components/Spinner.tsx
- [x] TypeScript types exported
- [x] All size and color variants work correctly
- [x] Storybook stories created with comprehensive examples
- [x] Component exported from src/index.ts
- [x] Accessible to screen readers with proper ARIA attributes
- [x] CSS animation smooth using Tailwind's animate-spin

🤖 Generated with [Claude Code](https://claude.com/claude-code)